### PR TITLE
chore: release 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vitest-environment-clarinet",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vitest-environment-clarinet",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "GPL-3.0",
       "peerDependencies": {
         "@hirosystems/clarinet-sdk": ">=2.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitest-environment-clarinet",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "A vitest environment to test Clarinet projects",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
This 2.5.0 doesn't introduce anything new, except for updated package-lock, and it will be the first release from stx-labs.
It will introduce the NPM provenance certificate through verified publisher 👍 