### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ A vitest environment to test Clarinet projects.
 
 [Learn more about Clarinet](https://www.hiro.so/clarinet)
 
-This project is used in the [clarinet-sdk](https://www.npmjs.com/package/@hirosystems/clarinet-sdk) to provide a Vitest testing enviroments for Clarinet projects.
-Allowing to access the Clarient simnet and interact with smart contracts.
+This project is used in the [clarinet-sdk](https://www.npmjs.com/package/@hirosystems/clarinet-sdk)
+to provide a Vitest testing enviroments for Clarinet projects. Allowing to access the Clarinet
+simnet and interact with smart contracts.


### PR DESCRIPTION
Old typo
Found it by wrongfully searching `Clarient` on npm and only got one match)